### PR TITLE
Refactor API handling and add Transaction service for Mayar Headless API V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,16 @@ $mayarId = new \ReactMoreTech\MayarHeadlessAPI\MayarProvider([
 See Example on [WIKI](https://github.com/reactmore-tech/mayar-headless-api/wiki):
 
 - [ ] Product
-  - [ ] Product Page
-  - [ ] Product Page with Type Filter
-  - [ ] Search Product
-  - [ ] Detail Product
-  - [ ] Close Product
-  - [ ] Re-open Product
 - [ ] Invoice
 - [ ] Request Payment
 - [ ] Installment
 - [ ] Discount & Coupon
 - [ ] Cart
 - [X] Customer
-- [ ] Transaction
+- [X] Transaction
 - [X] Webhook
-  - [X] Get History
-  - [X] Register URL Webhook
-  - [X] Test URL Webhook
-  - [X] Retry URL Webhook
 - [X] Software License Code
-- [ ] SaaS Membership License
+- [X] SaaS Membership License
 
 Note that this repository is currently under development, additional classes and endpoints being actively added.
 

--- a/src/Adapter/Guzzle.php
+++ b/src/Adapter/Guzzle.php
@@ -105,12 +105,20 @@ class Guzzle implements AdapterInterface
             throw new InvalidArgumentException('Request method must be get, post, put, patch, or delete');
         }
 
+        if (isset($data['json'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
         $options = [
             'headers' => $headers,
         ];
 
         if ($method === 'get') {
-            $options['query'] = $data;
+            if (isset($data['json'])) {
+                $options['json'] = $data['json'];
+            } else {
+                $options['query'] = $data;
+            }
         } elseif ($method === 'post' || $method === 'put' || $method === 'patch' || $method === 'delete') {
             if (isset($data['json'])) {
                 $options['json'] = $data['json'];

--- a/src/Helper/ApiResponse.php
+++ b/src/Helper/ApiResponse.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ReactMoreTech\MayarHeadlessAPI\Helper;
+
+use JsonSerializable;
+
+/**
+ * API Response Wrapper Class
+ *
+ * @package ReactMoreTech\MayarHeadlessAPI\Helper
+ */
+class ApiResponse implements JsonSerializable
+{
+    /**
+     * @var array $response The response data.
+     */
+    private array $response;
+
+    /**
+     * Constructor.
+     *
+     * @param array $response Formatted response array.
+     */
+    public function __construct(array $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Convert response to array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->response;
+    }
+
+    /**
+     * Implement jsonSerialize to automatically return JSON.
+     *
+     * @return mixed
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->response;
+    }
+
+    /**
+     * Convert response to JSON.
+     *
+     * @return string
+     */
+    public function toJson(): string
+    {
+        return json_encode($this->response, JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * Magic method for accessing array keys like an object.
+     *
+     * @param string $key
+     * @return mixed|null
+     */
+    public function __get(string $key): mixed
+    {
+        return $this->response[$key] ?? null;
+    }
+
+    /**
+     * Magic method for converting object to string (default JSON).
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
+}

--- a/src/Helper/ResponseFormatter.php
+++ b/src/Helper/ResponseFormatter.php
@@ -16,7 +16,7 @@ class ResponseFormatter
      *
      * @param string $responseBody
      * @param string|null $message
-     * @return array
+     * @return ApiResponse
      */
     public static function formatResponse($responseBody, $message = null)
     {
@@ -29,12 +29,21 @@ class ResponseFormatter
             );
         }
 
-        return [
+        // Ambil data paginasi jika ada di response
+        $paginationKeys = ['hasMore', 'pageCount', 'pageSize', 'page'];
+        $paginationData = [];
+        foreach ($paginationKeys as $key) {
+            if (isset($response[$key])) {
+                $paginationData[$key] = $response[$key];
+            }
+        }
+
+        return new ApiResponse(array_merge([
             'success' => true,
-            'message' => $message ?? 'Request berhasil',
-            'data' => $response,
+            'message' => $response['messages'] ?? ($message ?? 'Request berhasil'),
+            'data' => $response['data'] ?? [],
             'status_code' => $response['statusCode'] ?? 200,
-        ];
+        ], $paginationData));
     }
 
     /**
@@ -46,11 +55,11 @@ class ResponseFormatter
      */
     public static function formatErrorResponse($message, $statusCode = 500)
     {
-        return [
+        return new ApiResponse([
             'success' => false,
             'message' => $message,
             'data' => null,
             'status_code' => $statusCode,
-        ];
+        ]);
     }
 }

--- a/src/Services/V1/Transaction.php
+++ b/src/Services/V1/Transaction.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace ReactMoreTech\MayarHeadlessAPI\Services\V1;
+
+use ReactMoreTech\MayarHeadlessAPI\Adapter\AdapterInterface;
+use ReactMoreTech\MayarHeadlessAPI\Helper\ResponseFormatter;
+use ReactMoreTech\MayarHeadlessAPI\Services\ServiceInterface;
+use ReactMoreTech\MayarHeadlessAPI\Services\Traits\BodyAccessorTrait;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Transaction Service for Mayar Headless API V1
+ *
+ * All you transaction history, transaction detail, unapid transaction here
+ *
+ * @package ReactMoreTech\MayarHeadlessAPI\Services\V1
+ */
+class Transaction implements ServiceInterface
+{
+    use BodyAccessorTrait;
+
+    /**
+     * HTTP adapter for API communication.
+     *
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * Transaction Service constructor.
+     *
+     * @param AdapterInterface $adapter HTTP adapter instance.
+     */
+    public function __construct(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Balance Account.
+     *
+     * @return array The formatted API response containing balance account.
+     * @throws \Exception If the request fails.
+     */
+    public function getBalance()
+    {
+        try {
+            $request = $this->adapter->get('hl/v1/balance');
+            return ResponseFormatter::formatResponse($request->getBody());
+        } catch (RequestException $e) {
+            return $this->handleException($e);
+        }
+    }
+
+    /**
+     * Get Paid data transactions.
+     *
+     * @param array $data Contains optional parameters such as 'page' and 'pageSize'.
+     * @return array The formatted API response containing customer data.
+     * @throws \Exception If the request fails.
+     */
+    public function paid(array $data = [])
+    {
+        try {
+            $request = $this->adapter->get("hl/v1/transactions", $data);
+            return ResponseFormatter::formatResponse($request->getBody());
+        } catch (RequestException $e) {
+            return $this->handleException($e);
+        }
+    }
+
+    /**
+     * get Unpaid data transactions.
+     *
+     * @param array $data Contains optional parameters such as 'page' and 'pageSize'.
+     * @return array The formatted API response containing customer data.
+     * @throws \Exception If the request fails.
+     */
+    public function unpaid(array $data = [])
+    {
+        try {
+            $request = $this->adapter->get("hl/v1/transactions/unpaid", $data);
+            return ResponseFormatter::formatResponse($request->getBody());
+        } catch (RequestException $e) {
+            return $this->handleException($e);
+        }
+    }
+
+    /**
+     * Get Static QRCode.
+     *
+     * This fiture only available for user who joined before 8 mei 2023
+     *
+     * @return object The formatted API response containing customer data.
+     * @throws \Exception If the request fails.
+     */
+    public function getStaticQRCode(int $amount)
+    {
+        try {
+            $request = $this->adapter->get("hl/v1/qrcode/static", [
+                'json' => ['amount' => $amount]
+            ]);
+            return ResponseFormatter::formatResponse($request->getBody());
+        } catch (RequestException $e) {
+            return $this->handleException($e);
+        }
+    }
+
+    /**
+     * Get Dynamic QRCode.
+     *
+     * This fiture only available for user who joined before 8 mei 2023
+     *
+     * @return object The formatted API response containing customer data.
+     * @throws \Exception If the request fails.
+     */
+    public function getDynamicQRCode(int $amount)
+    {
+        try {
+            $request = $this->adapter->post("hl/v1/qrcode/create", [
+                'json' => ['amount' => $amount]
+            ]);
+            return ResponseFormatter::formatResponse($request->getBody());
+        } catch (RequestException $e) {
+            return $this->handleException($e);
+        }
+    }
+
+    /**
+     * Handle API request exceptions.
+     *
+     * @param RequestException $e The caught exception.
+     * @return object Formatted error response with status code.
+     */
+    private function handleException(RequestException $e)
+{
+    $response = $e->getResponse();
+    $statusCode = $response ? $response->getStatusCode() : 500;
+    $responseBody = $response ? $response->getBody()->getContents() : null;
+
+    if ($responseBody) {
+        $errorData = json_decode($responseBody, true);
+        $errorMessage = $errorData['messages'] ?? 'An error occurred';
+        return ResponseFormatter::formatErrorResponse($errorMessage, $statusCode);
+    }
+
+    return ResponseFormatter::formatErrorResponse($e->getMessage(), $statusCode);
+}
+}
+


### PR DESCRIPTION
Refactor the Guzzle adapter to support JSON requests and introduce an ApiResponse helper class for standardized response handling. Implement a Transaction service with methods for balance inquiries, paid and unpaid transactions, and QR code generation. Update the README to reflect these changes.